### PR TITLE
ブラウザ投稿後の動きを確認

### DIFF
--- a/app/javascript/checked.js
+++ b/app/javascript/checked.js
@@ -1,65 +1,42 @@
 function check() {
-  // querySelectorAllメソッドで、postをクラス名にもつ要素を取得できます。
-  // postというクラス名を持つ要素はメモの数だけ存在
+  // 表示されているすべてのメモを取得している
   const posts = document.querySelectorAll(".post");
   posts.forEach(function (post) {
-    if (post.getAttribute("data-load") != null) {
+     if (post.getAttribute("data-load") != null) {
       return null;
     }
     post.setAttribute("data-load", "true");
-
-    // 要素1つずつに対して「クリック」した際、動作する処理を記述
-    // 処理としてaddEventListenerメソッドを使用、引数にclickの指定をする
+    // メモをクリックした場合に実行する処理を定義している
     post.addEventListener("click", () => {
-
-      // ここにクリックした時に行う「何らかの処理」を記述していく
-      // getAttributeで属性値を取得、メモのidを取得
+      // どのメモをクリックしたのか、カスタムデータを利用して取得している
       const postId = post.getAttribute("data-id");
-
-      // エンドポイントを呼び出すためXMLHttpRequestをしてHTTPリクエストを送る。
-      // オブジェクトを生成
+      // Ajaxに必要なオブジェクトを生成している
       const XHR = new XMLHttpRequest();
-
-      // httpメソッド:GET,path指定:/posts/${postId},非同期通信のON/OFF:true
+      // openでリクエストを初期化する
       XHR.open("GET", `/posts/${postId}`, true);
-
-      // リクエストを送る際に予め、レスポンスしてほしい情報の形式を指定する。
-      // レスポンスの形式はjsonとする。
+      // レスポンスのタイプを指定する
       XHR.responseType = "json";
-
-      // .sendメソッドを記述することで初めてリクエストが行える。
+      // sendでリクエストを送信する
       XHR.send();
-
-      // checked.jsに、レスポンスがあった場合の処理
-      // XHR.responseでレスポンスされてきたJSONにアクセスできる。
+      // レスポンスを受け取った時の処理を記述する
       XHR.onload = () => {
-        // レスポンスがエラーだった場合の処理
-        // ステータスコードの200は処理成功であるが、!=であるので、処理が成功しない場合を表している
         if (XHR.status != 200) {
           // レスポンスの HTTP ステータスを解析し、該当するエラーメッセージをアラートで表示するようにしている
           alert(`Error ${XHR.status}: ${XHR.statusText}`);
-
-          // javascriptから抜け出す
+          // 処理を終了している
           return null;          
         }
-        
         // レスポンスされたデータを変数itemに代入している
         const item = XHR.response.post;
         if (item.checked === true) {
-
-        // 既読状態であれば、灰色に変わるcssを適用するためのカスタムデータを追加している
+          // 既読状態であれば、灰色に変わるcssを適用するためのカスタムデータを追加している
           post.setAttribute("data-check", "true");
         } else if (item.checked === false) {
-        
-        // 未読状態であれば、カスタムデータを削除している
+          // 未読状態であれば、カスタムデータを削除している
           post.removeAttribute("data-check");
         }
       };
     });
   });
 }
-// ページを読み込んだらcheckを実行するのではなく、
-// window.addEventListener("load", check);
-
-// 一定時間ごとに、自動でcheckを実行する仕様にする。
 setInterval(check, 1000);

--- a/app/javascript/checked.js
+++ b/app/javascript/checked.js
@@ -1,42 +1,65 @@
 function check() {
-  // 表示されているすべてのメモを取得している
+  // querySelectorAllメソッドで、postをクラス名にもつ要素を取得できます。
+  // postというクラス名を持つ要素はメモの数だけ存在
   const posts = document.querySelectorAll(".post");
   posts.forEach(function (post) {
-     if (post.getAttribute("data-load") != null) {
+    if (post.getAttribute("data-load") != null) {
       return null;
     }
     post.setAttribute("data-load", "true");
-    // メモをクリックした場合に実行する処理を定義している
+
+    // 要素1つずつに対して「クリック」した際、動作する処理を記述
+    // 処理としてaddEventListenerメソッドを使用、引数にclickの指定をする
     post.addEventListener("click", () => {
-      // どのメモをクリックしたのか、カスタムデータを利用して取得している
+
+      // ここにクリックした時に行う「何らかの処理」を記述していく
+      // getAttributeで属性値を取得、メモのidを取得
       const postId = post.getAttribute("data-id");
-      // Ajaxに必要なオブジェクトを生成している
+
+      // エンドポイントを呼び出すためXMLHttpRequestをしてHTTPリクエストを送る。
+      // オブジェクトを生成
       const XHR = new XMLHttpRequest();
-      // openでリクエストを初期化する
+
+      // httpメソッド:GET,path指定:/posts/${postId},非同期通信のON/OFF:true
       XHR.open("GET", `/posts/${postId}`, true);
-      // レスポンスのタイプを指定する
+
+      // リクエストを送る際に予め、レスポンスしてほしい情報の形式を指定する。
+      // レスポンスの形式はjsonとする。
       XHR.responseType = "json";
-      // sendでリクエストを送信する
+
+      // .sendメソッドを記述することで初めてリクエストが行える。
       XHR.send();
-      // レスポンスを受け取った時の処理を記述する
+
+      // checked.jsに、レスポンスがあった場合の処理
+      // XHR.responseでレスポンスされてきたJSONにアクセスできる。
       XHR.onload = () => {
+        // レスポンスがエラーだった場合の処理
+        // ステータスコードの200は処理成功であるが、!=であるので、処理が成功しない場合を表している
         if (XHR.status != 200) {
           // レスポンスの HTTP ステータスを解析し、該当するエラーメッセージをアラートで表示するようにしている
           alert(`Error ${XHR.status}: ${XHR.statusText}`);
-          // 処理を終了している
+
+          // javascriptから抜け出す
           return null;          
         }
+        
         // レスポンスされたデータを変数itemに代入している
         const item = XHR.response.post;
         if (item.checked === true) {
-          // 既読状態であれば、灰色に変わるcssを適用するためのカスタムデータを追加している
+
+        // 既読状態であれば、灰色に変わるcssを適用するためのカスタムデータを追加している
           post.setAttribute("data-check", "true");
         } else if (item.checked === false) {
-          // 未読状態であれば、カスタムデータを削除している
+        
+        // 未読状態であれば、カスタムデータを削除している
           post.removeAttribute("data-check");
         }
       };
     });
   });
 }
+// ページを読み込んだらcheckを実行するのではなく、
+// window.addEventListener("load", check);
+
+// 一定時間ごとに、自動でcheckを実行する仕様にする。
 setInterval(check, 1000);

--- a/app/javascript/memo.js
+++ b/app/javascript/memo.js
@@ -1,15 +1,15 @@
 function memo(){
   const submit = document.getElementById("submit");
-  submit.addEventListener("click",(e) => {
+  submit.addEventListener("click", (e) => {
     const formData = new FormData(document.getElementById("form"));
     const XHR = new XMLHttpRequest();
-    XHR.open("POST","/posts",true);
+    XHR.open("POST", "/posts", true);
     XHR.responseType = "json";
     XHR.send(formData);
 
     // レスポンスがあった場合の処理
     XHR.onload = () => {
-      if (XHR.status != 200){
+      if (XHR.status != 200) {
         alert(`Error ${XHR.status}: ${XHR.statusText}`);
         return null;
       }
@@ -22,17 +22,17 @@ function memo(){
       const formText = document.getElementById("content");
       // メモとして描画する部分のHTMLを定義
       const HTML = `
-        <div  class="post" date-id=${item.id}>
-          <div class="post-date">
-            投稿日時:${item.created_at}
-          </div>
-          <div class="post-content">
-          ${item.content}
-          </div>
-        </div>`;
+      <div class="post" data-id=${item.id}>
+        <div class="post-date">
+          投稿日時：${item.created_at}
+        </div>
+        <div class="post-content">
+        ${item.content}
+        </div>
+      </div>`;
         // listという要素に対して、insertAdjacentHTMLでHTMLを追加します。
         // 第一引数にafterendを指定することで、要素listの直後に挿入
-        list.insertAdjacentHTML("afterend",HTML);
+       list.insertAdjacentHTML("afterend", HTML);
         // 空の文字列を上書きすることでメモの入力フォームをリセットさせている。
         formText.value = "";
     };

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,6 @@
 <h1>AjaxApp</h1>
-  <%= form_with url: "/posts", method: :post,id: "form" do |form| %>
-  <%# contentを取得 %>
-  <%= form.text_field :content ,id: "content"%>
+<%= form_with url:  "/posts", method: :post,id: "form" do |form| %>
+  <%= form.text_field :content %>
   <%= form.submit '投稿する' , id: "submit" %>
 <% end %>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,6 @@
 <h1>AjaxApp</h1>
 <%= form_with url:  "/posts", method: :post,id: "form" do |form| %>
+<%# contentを取得 %>
   <%= form.text_field :content %>
   <%= form.submit '投稿する' , id: "submit" %>
 <% end %>


### PR DESCRIPTION
# what
メッセージ投稿後、クリックしてもイベントが発生しない（メッセージがグレーにならない）
ブラウザを更新しないとクリックイベントが発生しない現象を解決するため。

# why
memo.jsにある
```
      <div class="post" data-id=${item.id}>
        <div class="post-date">
          投稿日時：${item.created_at}
        </div>
        <div class="post-content">
        ${item.content}
        </div>
      </div>`;
```
こちらのdata-id を date-id とタイプミスをしていた。

このタイプミスをするとメモを投稿する動作はできるが
クリック動作をcheck.jsで設定してある

      const postId = post.getAttribute("data-id");
こちらで代入しているidが取得できないため４０４のステータスエラーが発生していた。

更新をするとクリックイベントが発火していたのは
index.html.erbよりdata-idを取得できるからイベントが発火できるのだろうと考えている。